### PR TITLE
Allow selecting entrants to bulk edit weights

### DIFF
--- a/idm-membership/admin/class-admin.php
+++ b/idm-membership/admin/class-admin.php
@@ -103,7 +103,9 @@ class Admin {
             ? self::apply_weights(self::get_campaign_entries($selected_campaign), $current_weights)
             : [];
 
-        echo '<div class="wrap idm-dashboard">';
+        list($selected_entries, $manual_weights) = self::prepare_weight_selection($entries, $current_weights);
+
+        echo '<div class="wrap idm-dashboard" data-default-weight="' . esc_attr(self::DEFAULT_WEIGHT) . '">';
         echo '<h1>' . esc_html__('独自会員 ダッシュボード', 'idm-membership') . '</h1>';
 
         self::render_notices();
@@ -122,8 +124,8 @@ class Admin {
             return;
         }
 
-        self::render_entries_section($entries);
-        self::render_weights_form($selected_campaign, $current_weights);
+        self::render_entries_section($entries, $selected_entries);
+        self::render_weights_form($selected_campaign, $manual_weights, $selected_entries);
         self::render_draw_section($entries);
 
         do_action('idm_membership_admin_dashboard', $selected_campaign, $entries, $current_weights);
@@ -159,7 +161,7 @@ class Admin {
         echo '</form>';
     }
 
-    private static function render_entries_section(array $entries) {
+    private static function render_entries_section(array $entries, array $selected_entries) {
         echo '<h2>' . esc_html__('応募者一覧', 'idm-membership') . '</h2>';
         if (empty($entries)) {
             echo '<p class="idm-empty">' . esc_html__('応募者がまだいません。', 'idm-membership') . '</p>';
@@ -174,86 +176,290 @@ class Admin {
 
         echo '<table class="widefat fixed striped">';
         echo '<thead><tr>';
+        echo '<th class="idm-entrant-column-select">';
+        echo '<input type="checkbox" id="idm-entrant-select-all" />';
+        echo '<label for="idm-entrant-select-all" class="screen-reader-text">' . esc_html__('全て選択', 'idm-membership') . '</label>';
+        echo '</th>';
         echo '<th>' . esc_html__('名前', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('メールアドレス', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('応募日時', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('抽選確率(%)', 'idm-membership') . '</th>';
         echo '</tr></thead>';
         echo '<tbody class="idm-entrant-list">';
-        foreach ($entries as $entry) {
-            $name  = $entry['name'] !== '' ? $entry['name'] : __('(未設定)', 'idm-membership');
-            $email = $entry['email'] !== '' ? $entry['email'] : __('(メール不明)', 'idm-membership');
-            printf(
-                '<tr class="idm-entrant" data-member-id="%1$d" data-weight="%4$d"><td>%2$s</td><td>%3$s</td><td>%5$s</td><td>%4$d</td></tr>',
-                (int) $entry['member_id'],
-                esc_html($name),
-                esc_html($email),
-                (int) $entry['weight'],
-                esc_html($entry['joined_at'])
+        foreach ($entries as $index => $entry) {
+            $name_raw  = isset($entry['name']) ? (string) $entry['name'] : '';
+            $email_raw = isset($entry['email']) ? (string) $entry['email'] : '';
+            $name      = $name_raw !== '' ? $name_raw : __('(未設定)', 'idm-membership');
+            $email     = $email_raw !== '' ? $email_raw : __('(メール不明)', 'idm-membership');
+            $weight    = isset($entry['weight']) ? max(1, (int) $entry['weight']) : self::DEFAULT_WEIGHT;
+            $entry_key = self::get_entry_key($entry);
+            $is_selected = isset($selected_entries[$entry_key]);
+            $checkbox_id = 'idm-entrant-select-' . (isset($entry['id']) ? (int) $entry['id'] : $index);
+
+            $row_classes = ['idm-entrant'];
+            if ($is_selected) {
+                $row_classes[] = 'is-selected';
+            }
+
+            $row_attrs = sprintf(
+                ' data-entry-key="%1$s" data-member-id="%2$s" data-email="%3$s" data-name="%4$s" data-weight="%5$d" data-default-weight="%6$d"',
+                esc_attr($entry_key),
+                esc_attr((string) ($entry['member_id'] ?? '')),
+                esc_attr($email_raw),
+                esc_attr($name_raw),
+                $weight,
+                self::DEFAULT_WEIGHT
             );
+
+            echo '<tr class="' . esc_attr(implode(' ', $row_classes)) . '"' . $row_attrs . '>';
+            echo '<td class="idm-entrant-select">';
+            echo '<input type="checkbox" class="idm-entrant-checkbox" id="' . esc_attr($checkbox_id) . '" data-entry-key="' . esc_attr($entry_key) . '" value="1"' . ($is_selected ? ' checked="checked"' : '') . ' />';
+            echo '<label for="' . esc_attr($checkbox_id) . '" class="screen-reader-text">' . esc_html__('応募者を選択', 'idm-membership') . '</label>';
+            echo '</td>';
+            echo '<td>' . esc_html($name) . '</td>';
+            echo '<td>' . esc_html($email) . '</td>';
+            echo '<td>' . esc_html($entry['joined_at']) . '</td>';
+            echo '<td class="idm-entrant-weight"><span class="idm-entrant-weight-value">' . esc_html($weight) . '</span> %</td>';
+            echo '</tr>';
         }
         echo '</tbody>';
         echo '</table>';
     }
 
-    private static function render_weights_form($campaign, array $weights) {
+    private static function render_weights_form($campaign, array $manual_weights, array $selected_entries) {
         echo '<h2>' . esc_html__('抽選確率の調整', 'idm-membership') . '</h2>';
-        echo '<p class="description">' . esc_html__('特定の会員を名前またはメールアドレスで指定し、抽選確率を％で上書きできます。未指定の応募者は100%（等確率）です。', 'idm-membership') . '</p>';
+        echo '<p class="description">' . esc_html__('応募者一覧でチェックした応募者を下にまとめて表示し、抽選確率を一括で変更できます。未指定の応募者は100%（等確率）です。', 'idm-membership') . '</p>';
 
         echo '<form method="post" class="idm-weights-form">';
         wp_nonce_field('idm_save_weights');
         echo '<input type="hidden" name="idm_action" value="save_weights" />';
         echo '<input type="hidden" name="campaign" value="' . esc_attr($campaign) . '" />';
 
-        echo '<table class="widefat fixed striped">';
+        $selected_list = array_values($selected_entries);
+        $has_selected  = !empty($selected_list);
+
+        echo '<div class="idm-selected-section">';
+        echo '<h3>' . esc_html__('選択した応募者', 'idm-membership') . '</h3>';
+        echo '<p class="description">' . esc_html__('上の応募者一覧でチェックした応募者がここに表示されます。確率を入力して保存すると設定が適用されます。', 'idm-membership') . '</p>';
+        echo '<p class="idm-selected-empty"' . ($has_selected ? ' style="display:none;"' : '') . '>' . esc_html__('応募者を選択するとここに表示されます。', 'idm-membership') . '</p>';
+
+        echo '<table class="widefat fixed striped idm-selected-table">';
+        echo '<thead><tr>';
+        echo '<th>' . esc_html__('名前', 'idm-membership') . '</th>';
+        echo '<th>' . esc_html__('メールアドレス', 'idm-membership') . '</th>';
+        echo '<th>' . esc_html__('確率(%)', 'idm-membership') . '</th>';
+        echo '<th class="idm-column-actions"></th>';
+        echo '</tr></thead>';
+        echo '<tbody id="idm-selected-entries">';
+
+        $selected_index = 0;
+        foreach ($selected_list as $selected) {
+            self::render_selected_entry_row($selected_index, $selected);
+            $selected_index++;
+        }
+
+        echo '</tbody>';
+        echo '</table>';
+
+        echo '<div class="idm-bulk-actions idm-selected-bulk">';
+        echo '<label for="idm-selected-bulk">' . esc_html__('選択中の応募者の確率をまとめて変更', 'idm-membership') . '</label>';
+        echo '<input type="number" id="idm-selected-bulk" min="1" max="1000" class="small-text" /> %';
+        echo '<button type="button" class="button" id="idm-apply-selected-bulk">' . esc_html__('一括適用', 'idm-membership') . '</button>';
+        echo '</div>';
+        echo '</div>';
+
+        echo '<div class="idm-manual-section">';
+        echo '<h3>' . esc_html__('その他の条件', 'idm-membership') . '</h3>';
+        echo '<p class="description">' . esc_html__('応募者に紐付かない条件を追加したい場合は、対象と識別値を指定して確率を登録できます。', 'idm-membership') . '</p>';
+
+        echo '<table class="widefat fixed striped idm-manual-table">';
         echo '<thead><tr>';
         echo '<th>' . esc_html__('対象', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('識別値', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('確率(%)', 'idm-membership') . '</th>';
         echo '<th class="idm-column-actions"></th>';
         echo '</tr></thead>';
-        echo '<tbody id="idm-weight-rows">';
+        echo '<tbody id="idm-manual-rows">';
 
-        if (empty($weights)) {
-            $weights = [];
-        }
-
-        $index = 0;
-        foreach ($weights as $weight) {
+        $manual_index = 0;
+        foreach ($manual_weights as $weight) {
             $field  = isset($weight['field']) ? $weight['field'] : 'email';
             $value  = isset($weight['value']) ? $weight['value'] : '';
-            $chance = isset($weight['weight']) ? (int)$weight['weight'] : self::DEFAULT_WEIGHT;
-            self::render_weight_row($index, $field, $value, $chance);
-            $index++;
+            $chance = isset($weight['weight']) ? (int) $weight['weight'] : self::DEFAULT_WEIGHT;
+            self::render_manual_weight_row($manual_index, $field, $value, $chance);
+            $manual_index++;
         }
 
-        // Empty template row (will be cloned by JS when adding new rule).
-        self::render_weight_row('__INDEX__', 'email', '', self::DEFAULT_WEIGHT, true);
+        self::render_manual_weight_row('__INDEX__', 'email', '', self::DEFAULT_WEIGHT, true);
 
         echo '</tbody>';
         echo '</table>';
 
-        echo '<p><button type="button" class="button" id="idm-add-weight">' . esc_html__('＋ 条件を追加', 'idm-membership') . '</button></p>';
+        echo '<p><button type="button" class="button" id="idm-add-manual">' . esc_html__('＋ 条件を追加', 'idm-membership') . '</button></p>';
+        echo '</div>';
+
         submit_button(__('設定を保存', 'idm-membership'));
+
+        echo '<template id="idm-selected-entry-template">';
+        self::render_selected_entry_row('__INDEX__', [
+            'entry'  => ['member_id' => '', 'name' => '', 'email' => ''],
+            'weight' => self::DEFAULT_WEIGHT,
+            'key'    => '',
+        ], true);
+        echo '</template>';
+
         echo '</form>';
     }
 
-    private static function render_weight_row($index, $field, $value, $chance, $is_template = false) {
-        $tr_class = $is_template ? 'idm-weight-row is-template' : 'idm-weight-row';
-        $name_prefix = is_numeric($index) ? 'weights[' . $index . ']' : 'weights[__INDEX__]';
+    private static function render_selected_entry_row($index, array $data, $is_template = false) {
+        $entry     = isset($data['entry']) && is_array($data['entry']) ? $data['entry'] : [];
+        $member_id = isset($entry['member_id']) ? (int) $entry['member_id'] : 0;
+        $name_raw  = isset($entry['name']) ? (string) $entry['name'] : '';
+        $email_raw = isset($entry['email']) ? (string) $entry['email'] : '';
+        $name      = $name_raw !== '' ? $name_raw : __('(未設定)', 'idm-membership');
+        $email     = $email_raw !== '' ? $email_raw : __('(メール不明)', 'idm-membership');
+        $weight    = isset($data['weight']) ? max(1, (int) $data['weight']) : self::DEFAULT_WEIGHT;
+        $key       = isset($data['key']) ? (string) $data['key'] : self::get_entry_key($entry);
+
+        $name_prefix = is_numeric($index)
+            ? 'selected[' . (int) $index . ']'
+            : 'selected[__INDEX__]';
+
+        $attributes = ['class="idm-selected-row"'];
+        if ($is_template) {
+            $attributes[] = 'data-template="1"';
+        }
+        $attributes[] = 'data-entry-key="' . esc_attr($key) . '"';
+        $attributes[] = 'data-member-id="' . esc_attr((string) $member_id) . '"';
+        $attributes[] = 'data-email="' . esc_attr($email_raw) . '"';
+        $attributes[] = 'data-name="' . esc_attr($name_raw) . '"';
+
+        echo '<tr ' . implode(' ', $attributes) . '>';
+        echo '<td class="idm-selected-name">' . esc_html($name) . '</td>';
+        echo '<td class="idm-selected-email">' . esc_html($email) . '</td>';
+        echo '<td class="idm-selected-weight">';
+        echo '<input type="hidden" data-field="member_id" name="' . esc_attr($name_prefix . '[member_id]') . '" value="' . esc_attr($member_id > 0 ? (string) $member_id : '') . '" />';
+        echo '<input type="hidden" data-field="email" name="' . esc_attr($name_prefix . '[email]') . '" value="' . esc_attr($email_raw) . '" />';
+        echo '<input type="hidden" data-field="name" name="' . esc_attr($name_prefix . '[name]') . '" value="' . esc_attr($name_raw) . '" />';
+        echo '<input type="number" data-field="weight" name="' . esc_attr($name_prefix . '[weight]') . '" value="' . esc_attr($weight) . '" min="1" max="1000" class="small-text" /> %';
+        echo '</td>';
+        echo '<td class="idm-selected-actions"><button type="button" class="button-link-delete idm-remove-selected">' . esc_html__('除外', 'idm-membership') . '</button></td>';
+        echo '</tr>';
+    }
+
+    private static function render_manual_weight_row($index, $field, $value, $chance, $is_template = false) {
+        $tr_class = $is_template ? 'idm-manual-row is-template' : 'idm-manual-row';
+        $name_prefix = is_numeric($index) ? 'manual[' . $index . ']' : 'manual[__INDEX__]';
         $disabled = $is_template ? ' disabled="disabled"' : '';
 
         echo '<tr class="' . esc_attr($tr_class) . '"' . ($is_template ? ' data-template="1" style="display:none;"' : '') . '>';
         echo '<td>';
-        echo '<select name="' . esc_attr($name_prefix . '[field]') . '"' . $disabled . '>';
+        echo '<select data-field="field" name="' . esc_attr($name_prefix . '[field]') . '"' . $disabled . '>';
         printf('<option value="email" %s>%s</option>', selected($field, 'email', false), esc_html__('メールアドレス', 'idm-membership'));
         printf('<option value="name" %s>%s</option>', selected($field, 'name', false), esc_html__('名前', 'idm-membership'));
         echo '</select>';
         echo '</td>';
-        echo '<td><input type="text" name="' . esc_attr($name_prefix . '[value]') . '" value="' . esc_attr($value) . '" class="regular-text"' . $disabled . ' /></td>';
-        echo '<td><input type="number" name="' . esc_attr($name_prefix . '[weight]') . '" value="' . esc_attr($chance) . '" min="1" max="1000" class="small-text"' . $disabled . ' /> %</td>';
+        echo '<td><input type="text" data-field="value" name="' . esc_attr($name_prefix . '[value]') . '" value="' . esc_attr($value) . '" class="regular-text"' . $disabled . ' /></td>';
+        echo '<td><input type="number" data-field="weight" name="' . esc_attr($name_prefix . '[weight]') . '" value="' . esc_attr($chance) . '" min="1" max="1000" class="small-text"' . $disabled . ' /> %</td>';
         echo '<td class="idm-column-actions"><button type="button" class="button-link-delete idm-remove-weight"' . ($is_template ? ' disabled="disabled"' : '') . '>' . esc_html__('削除', 'idm-membership') . '</button></td>';
         echo '</tr>';
+    }
+
+    private static function prepare_weight_selection(array $entries, array $weights) {
+        $selected = [];
+        $manual   = [];
+
+        if (empty($weights)) {
+            return [$selected, $manual];
+        }
+
+        $by_member = [];
+        $by_email  = [];
+        $by_name   = [];
+
+        foreach ($entries as $entry) {
+            if (!empty($entry['member_id'])) {
+                $by_member[(int) $entry['member_id']] = $entry;
+            }
+            if (!empty($entry['email'])) {
+                $by_email[strtolower((string) $entry['email'])] = $entry;
+            }
+            if (!empty($entry['name'])) {
+                $by_name[(string) $entry['name']][] = $entry;
+            }
+        }
+
+        foreach ($weights as $weight) {
+            $field  = isset($weight['field']) ? (string) $weight['field'] : 'email';
+            $value  = isset($weight['value']) ? (string) $weight['value'] : '';
+            $chance = isset($weight['weight']) ? (int) $weight['weight'] : self::DEFAULT_WEIGHT;
+
+            $matched_entry = null;
+
+            if ($field === 'member_id') {
+                $member_id = (int) $value;
+                if ($member_id > 0 && isset($by_member[$member_id])) {
+                    $matched_entry = $by_member[$member_id];
+                }
+            } elseif ($field === 'email') {
+                $email = strtolower($value);
+                if ($email !== '' && isset($by_email[$email])) {
+                    $matched_entry = $by_email[$email];
+                }
+            } elseif ($field === 'name') {
+                if ($value !== '' && isset($by_name[$value]) && count($by_name[$value]) === 1) {
+                    $matched_entry = $by_name[$value][0];
+                }
+            }
+
+            if ($matched_entry) {
+                $key = self::get_entry_key($matched_entry);
+                $selected[$key] = [
+                    'entry'  => $matched_entry,
+                    'weight' => max(1, $chance),
+                    'field'  => $field,
+                    'value'  => $value,
+                    'key'    => $key,
+                ];
+                continue;
+            }
+
+            $manual[] = [
+                'field'  => $field,
+                'value'  => $value,
+                'weight' => max(1, $chance),
+            ];
+        }
+
+        if (!empty($selected)) {
+            $ordered = [];
+            foreach ($entries as $entry) {
+                $key = self::get_entry_key($entry);
+                if (isset($selected[$key])) {
+                    $ordered[$key] = $selected[$key];
+                }
+            }
+            $selected = $ordered;
+        }
+
+        return [$selected, $manual];
+    }
+
+    private static function get_entry_key(array $entry) {
+        if (!empty($entry['member_id'])) {
+            return 'member:' . (int) $entry['member_id'];
+        }
+        if (!empty($entry['email'])) {
+            return 'email:' . strtolower((string) $entry['email']);
+        }
+        if (!empty($entry['id'])) {
+            return 'join:' . (int) $entry['id'];
+        }
+        if (!empty($entry['name'])) {
+            return 'name:' . (string) $entry['name'];
+        }
+
+        return 'entry:' . md5(wp_json_encode($entry));
     }
 
     private static function render_draw_section(array $entries) {
@@ -300,8 +506,12 @@ class Admin {
             return null;
         }
 
-        $weights_input = isset($_POST['weights']) ? wp_unslash($_POST['weights']) : [];
-        $sanitized     = self::sanitize_weights($weights_input);
+        $selected_input = isset($_POST['selected']) ? wp_unslash($_POST['selected']) : [];
+        $manual_input   = isset($_POST['manual']) ? wp_unslash($_POST['manual']) : [];
+
+        $selected_weights = self::sanitize_selected_weights($selected_input);
+        $manual_weights   = self::sanitize_manual_weights($manual_input);
+        $sanitized        = array_merge($selected_weights, $manual_weights);
 
         $options = self::get_weight_options();
         if (empty($sanitized)) {
@@ -319,7 +529,57 @@ class Admin {
         return $submitted_campaign;
     }
 
-    private static function sanitize_weights($weights) {
+    private static function sanitize_selected_weights($weights) {
+        $clean = [];
+        if (!is_array($weights)) {
+            return $clean;
+        }
+
+        foreach ($weights as $weight) {
+            if (!is_array($weight)) {
+                continue;
+            }
+
+            $chance = isset($weight['weight']) ? intval($weight['weight']) : self::DEFAULT_WEIGHT;
+            if ($chance <= 0) {
+                continue;
+            }
+
+            $member_id = isset($weight['member_id']) ? intval($weight['member_id']) : 0;
+            $email     = isset($weight['email']) ? sanitize_email($weight['email']) : '';
+            $name      = isset($weight['name']) ? sanitize_text_field($weight['name']) : '';
+
+            if ($member_id > 0) {
+                $clean[] = [
+                    'field'  => 'member_id',
+                    'value'  => (string) $member_id,
+                    'weight' => $chance,
+                ];
+                continue;
+            }
+
+            if ($email !== '') {
+                $clean[] = [
+                    'field'  => 'email',
+                    'value'  => $email,
+                    'weight' => $chance,
+                ];
+                continue;
+            }
+
+            if ($name !== '') {
+                $clean[] = [
+                    'field'  => 'name',
+                    'value'  => $name,
+                    'weight' => $chance,
+                ];
+            }
+        }
+
+        return $clean;
+    }
+
+    private static function sanitize_manual_weights($weights) {
         $clean = [];
         if (!is_array($weights)) {
             return $clean;
@@ -360,7 +620,9 @@ class Admin {
         return $campaigns;
     }
 
-    private static function get_selected_campaign(?array $available = null) {
+    private static function get_selected_campaign($available = null) {
+        $available = is_array($available) ? $available : [];
+
         $campaign = isset($_GET['campaign']) ? sanitize_key(wp_unslash($_GET['campaign'])) : '';
         if ($campaign !== '') {
             if (empty($available) || in_array($campaign, $available, true)) {
@@ -368,7 +630,7 @@ class Admin {
             }
         }
 
-        if (is_array($available) && !empty($available)) {
+        if (!empty($available)) {
             return (string) reset($available);
         }
 
@@ -421,19 +683,28 @@ class Admin {
 
         foreach ($entries as &$entry) {
             $entry['weight'] = self::DEFAULT_WEIGHT;
+            $entry['weight_rule'] = null;
             foreach ($weights as $rule) {
                 $field = $rule['field'] ?? 'email';
                 $value = $rule['value'] ?? '';
                 $chance = isset($rule['weight']) ? (int) $rule['weight'] : self::DEFAULT_WEIGHT;
 
-                if ($field === 'email') {
+                if ($field === 'member_id') {
+                    if ((int) $entry['member_id'] === (int) $value && (int) $entry['member_id'] !== 0) {
+                        $entry['weight'] = max(1, $chance);
+                        $entry['weight_rule'] = $rule;
+                        break;
+                    }
+                } elseif ($field === 'email') {
                     if (strcasecmp((string) $entry['email'], (string) $value) === 0) {
                         $entry['weight'] = max(1, $chance);
+                        $entry['weight_rule'] = $rule;
                         break;
                     }
                 } elseif ($field === 'name') {
                     if ((string) $entry['name'] === (string) $value) {
                         $entry['weight'] = max(1, $chance);
+                        $entry['weight_rule'] = $rule;
                         break;
                     }
                 }

--- a/idm-membership/admin/dashboard.css
+++ b/idm-membership/admin/dashboard.css
@@ -20,19 +20,67 @@
 
 .idm-dashboard .idm-weights-form {
   margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
-.idm-dashboard .idm-weights-form table input[type="number"] {
+.idm-dashboard .idm-entrant-column-select,
+.idm-dashboard .idm-entrant-select {
+  width: 56px;
+  text-align: center;
+}
+
+.idm-dashboard .idm-entrant-select input {
+  margin: 0;
+}
+
+.idm-dashboard .idm-entrant.is-selected .idm-entrant-weight-value {
+  font-weight: 600;
+  color: #2271b1;
+}
+
+.idm-dashboard .idm-selected-section,
+.idm-dashboard .idm-manual-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.idm-dashboard .idm-selected-section table,
+.idm-dashboard .idm-manual-section table {
+  margin-top: 4px;
+}
+
+.idm-dashboard .idm-selected-empty {
+  margin: 0;
+  color: #646970;
+}
+
+.idm-dashboard .idm-selected-table .idm-selected-weight input[type="number"],
+.idm-dashboard .idm-manual-table input[type="number"] {
   width: 6em;
 }
 
-.idm-dashboard .idm-weights-form .idm-column-actions {
+.idm-dashboard .idm-selected-actions,
+.idm-dashboard .idm-manual-table .idm-column-actions {
   width: 100px;
   text-align: center;
 }
 
 .idm-dashboard .idm-weights-form .button-link-delete {
   color: #d63638;
+}
+
+.idm-dashboard .idm-selected-bulk {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.idm-dashboard #idm-selected-bulk {
+  width: 6em;
 }
 
 .idm-dashboard #idm-draw-button {

--- a/idm-membership/admin/dashboard.js
+++ b/idm-membership/admin/dashboard.js
@@ -7,61 +7,407 @@
     return Array.prototype.slice.call((context || document).querySelectorAll(selector));
   }
 
-  function addWeightRow() {
-    var template = document.querySelector('.idm-weight-row[data-template="1"]');
-    var tbody = document.getElementById('idm-weight-rows');
-    if (!template || !tbody) {
+  function escapeSelector(value) {
+    if (window.CSS && window.CSS.escape) {
+      return window.CSS.escape(value);
+    }
+    return value.replace(/([\0-\x1F\x7F\s!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g, '\\$1');
+  }
+
+  var dashboard = document.querySelector('.idm-dashboard');
+  var defaultWeight = dashboard ? parseInt(dashboard.getAttribute('data-default-weight'), 10) : NaN;
+  if (isNaN(defaultWeight) || defaultWeight <= 0) {
+    defaultWeight = 100;
+  }
+
+  var entrantSelectAll = document.getElementById('idm-entrant-select-all');
+  var selectedBody = document.getElementById('idm-selected-entries');
+  var selectedTemplate = document.getElementById('idm-selected-entry-template');
+  var selectedEmpty = document.querySelector('.idm-selected-empty');
+  var selectedBulkInput = document.getElementById('idm-selected-bulk');
+  var selectedBulkButton = document.getElementById('idm-apply-selected-bulk');
+  var manualBody = document.getElementById('idm-manual-rows');
+  var manualTemplate = manualBody ? manualBody.querySelector('.idm-manual-row[data-template="1"]') : null;
+  var addManualButton = document.getElementById('idm-add-manual');
+
+  function getEntryRowByKey(key) {
+    if (!key) {
+      return null;
+    }
+    return document.querySelector('.idm-entrant[data-entry-key="' + escapeSelector(key) + '"]');
+  }
+
+  function syncEntryWeightDisplay(entryRow, weight) {
+    if (!entryRow) {
       return;
     }
+    entryRow.setAttribute('data-weight', weight);
+    var valueEl = entryRow.querySelector('.idm-entrant-weight-value');
+    if (valueEl) {
+      valueEl.textContent = weight;
+    }
+  }
 
-    var clone = template.cloneNode(true);
+  function resetEntryWeight(entryRow) {
+    if (!entryRow) {
+      return;
+    }
+    var base = parseInt(entryRow.getAttribute('data-default-weight'), 10);
+    if (isNaN(base) || base <= 0) {
+      base = defaultWeight;
+    }
+    syncEntryWeightDisplay(entryRow, base);
+    entryRow.classList.remove('is-selected');
+  }
+
+  function renumberSelectedRows() {
+    if (!selectedBody) {
+      return;
+    }
+    $all('.idm-selected-row', selectedBody).forEach(function(row, index) {
+      $all('[data-field]', row).forEach(function(input) {
+        var field = input.getAttribute('data-field');
+        if (!field) {
+          return;
+        }
+        input.setAttribute('name', 'selected[' + index + '][' + field + ']');
+      });
+    });
+  }
+
+  function renumberManualRows() {
+    if (!manualBody) {
+      return;
+    }
+    $all('.idm-manual-row', manualBody).forEach(function(row, index) {
+      if (row.hasAttribute('data-template')) {
+        return;
+      }
+      $all('[data-field]', row).forEach(function(input) {
+        var field = input.getAttribute('data-field');
+        if (!field) {
+          return;
+        }
+        input.setAttribute('name', 'manual[' + index + '][' + field + ']');
+      });
+    });
+  }
+
+  function updateSelectedEmptyState() {
+    if (!selectedBody) {
+      return;
+    }
+    var hasRows = $all('.idm-selected-row', selectedBody).length > 0;
+    if (selectedEmpty) {
+      selectedEmpty.style.display = hasRows ? 'none' : '';
+    }
+    var table = selectedBody.closest('table');
+    if (table) {
+      table.style.display = hasRows ? '' : 'none';
+    }
+    if (selectedBulkInput) {
+      selectedBulkInput.disabled = !hasRows;
+    }
+    if (selectedBulkButton) {
+      selectedBulkButton.disabled = !hasRows;
+    }
+  }
+
+  function updateEntrantSelectAll() {
+    if (!entrantSelectAll) {
+      return;
+    }
+    var boxes = $all('.idm-entrant-checkbox');
+    if (!boxes.length) {
+      entrantSelectAll.checked = false;
+      entrantSelectAll.indeterminate = false;
+      return;
+    }
+    var checkedCount = boxes.filter(function(box) { return box.checked; }).length;
+    entrantSelectAll.checked = checkedCount === boxes.length;
+    entrantSelectAll.indeterminate = checkedCount > 0 && checkedCount < boxes.length;
+  }
+
+  function ensureSelectedRow(entryRow) {
+    if (!selectedBody || !entryRow) {
+      return null;
+    }
+    var key = entryRow.getAttribute('data-entry-key');
+    if (!key) {
+      return null;
+    }
+
+    var existing = selectedBody.querySelector('.idm-selected-row[data-entry-key="' + escapeSelector(key) + '"]');
+    var weight = parseInt(entryRow.getAttribute('data-weight'), 10);
+    if (isNaN(weight) || weight <= 0) {
+      weight = defaultWeight;
+    }
+
+    if (existing) {
+      var input = existing.querySelector('[data-field="weight"]');
+      if (input) {
+        input.value = weight;
+      }
+      entryRow.classList.add('is-selected');
+      syncEntryWeightDisplay(entryRow, weight);
+      return existing;
+    }
+
+    var templateRow = null;
+    if (selectedTemplate && 'content' in selectedTemplate) {
+      templateRow = selectedTemplate.content.querySelector('.idm-selected-row');
+    }
+
+    var clone = templateRow ? templateRow.cloneNode(true) : document.createElement('tr');
+    if (!templateRow) {
+      clone.className = 'idm-selected-row';
+      clone.innerHTML = '';
+    }
+
+    clone.setAttribute('data-entry-key', key);
+    clone.setAttribute('data-member-id', entryRow.getAttribute('data-member-id') || '');
+    clone.setAttribute('data-email', entryRow.getAttribute('data-email') || '');
+    clone.setAttribute('data-name', entryRow.getAttribute('data-name') || '');
+
+    var sourceNameCell = entryRow.querySelector('td:nth-child(2)');
+    var sourceEmailCell = entryRow.querySelector('td:nth-child(3)');
+    var nameCell = clone.querySelector('.idm-selected-name');
+    var emailCell = clone.querySelector('.idm-selected-email');
+    if (nameCell && sourceNameCell) {
+      nameCell.textContent = sourceNameCell.textContent.trim();
+    }
+    if (emailCell && sourceEmailCell) {
+      emailCell.textContent = sourceEmailCell.textContent.trim();
+    }
+
+    var memberField = clone.querySelector('[data-field="member_id"]');
+    if (memberField) {
+      memberField.value = entryRow.getAttribute('data-member-id') || '';
+    }
+    var emailField = clone.querySelector('[data-field="email"]');
+    if (emailField) {
+      emailField.value = entryRow.getAttribute('data-email') || '';
+    }
+    var nameField = clone.querySelector('[data-field="name"]');
+    if (nameField) {
+      nameField.value = entryRow.getAttribute('data-name') || '';
+    }
+    var weightField = clone.querySelector('[data-field="weight"]');
+    if (weightField) {
+      weightField.value = weight;
+    }
+
+    selectedBody.appendChild(clone);
+    entryRow.classList.add('is-selected');
+    syncEntryWeightDisplay(entryRow, weight);
+    renumberSelectedRows();
+    updateSelectedEmptyState();
+    return clone;
+  }
+
+  function removeSelectedRowByKey(key, options) {
+    if (!key || !selectedBody) {
+      return;
+    }
+    var row = selectedBody.querySelector('.idm-selected-row[data-entry-key="' + escapeSelector(key) + '"]');
+    if (row) {
+      row.parentNode.removeChild(row);
+      renumberSelectedRows();
+      updateSelectedEmptyState();
+    }
+
+    var entryRow = getEntryRowByKey(key);
+    if (entryRow) {
+      if (!options || !options.keepCheckbox) {
+        var checkbox = entryRow.querySelector('.idm-entrant-checkbox');
+        if (checkbox) {
+          checkbox.checked = false;
+        }
+      }
+      resetEntryWeight(entryRow);
+    }
+    updateEntrantSelectAll();
+  }
+
+  function handleEntrantToggle(checkbox) {
+    var row = checkbox.closest('.idm-entrant');
+    if (!row) {
+      return;
+    }
+    if (checkbox.checked) {
+      ensureSelectedRow(row);
+    } else {
+      removeSelectedRowByKey(row.getAttribute('data-entry-key'), { keepCheckbox: true });
+    }
+    updateEntrantSelectAll();
+  }
+
+  function addManualRow() {
+    if (!manualTemplate || !manualBody) {
+      return;
+    }
+    var clone = manualTemplate.cloneNode(true);
     clone.removeAttribute('data-template');
     clone.classList.remove('is-template');
     clone.style.display = '';
     $all('[disabled]', clone).forEach(function(el) {
       el.removeAttribute('disabled');
     });
-
-    var index = tbody.querySelectorAll('.idm-weight-row:not([data-template])').length;
-    $all('[name]', clone).forEach(function(el) {
-      var name = el.getAttribute('name');
-      if (name) {
-        el.setAttribute('name', name.replace('__INDEX__', index));
+    $all('[data-field]', clone).forEach(function(input) {
+      var field = input.getAttribute('data-field');
+      if (input.tagName === 'SELECT') {
+        input.value = 'email';
+      } else if (input.tagName === 'INPUT') {
+        if (input.type === 'number') {
+          var base = input.getAttribute('value') || defaultWeight;
+          input.value = base;
+          input.setAttribute('value', base);
+        } else {
+          input.value = '';
+        }
       }
-      if (el.tagName === 'INPUT') {
-        el.value = '';
+      if (field) {
+        input.setAttribute('name', 'manual[' + $all('.idm-manual-row:not([data-template])', manualBody).length + '][' + field + ']');
       }
     });
-
-    var select = $('select', clone);
-    if (select) {
-      select.value = 'email';
-    }
-
-    var number = $('input[type="number"]', clone);
-    if (number) {
-      var baseValue = number.getAttribute('value') || 100;
-      number.value = baseValue;
-      number.setAttribute('value', baseValue);
-    }
-
-    tbody.appendChild(clone);
+    manualBody.appendChild(clone);
+    renumberManualRows();
   }
 
-  var addButton = document.getElementById('idm-add-weight');
-  if (addButton) {
-    addButton.addEventListener('click', addWeightRow);
+  renumberSelectedRows();
+  renumberManualRows();
+  updateSelectedEmptyState();
+  updateEntrantSelectAll();
+
+  if (selectedBody) {
+    $all('.idm-selected-row', selectedBody).forEach(function(row) {
+      var key = row.getAttribute('data-entry-key');
+      if (!key) {
+        return;
+      }
+      var weightField = row.querySelector('[data-field="weight"]');
+      var weight = weightField ? parseInt(weightField.value, 10) : NaN;
+      if (isNaN(weight) || weight <= 0) {
+        weight = defaultWeight;
+      }
+      var entryRow = getEntryRowByKey(key);
+      if (entryRow) {
+        entryRow.classList.add('is-selected');
+        var checkbox = entryRow.querySelector('.idm-entrant-checkbox');
+        if (checkbox) {
+          checkbox.checked = true;
+        }
+        syncEntryWeightDisplay(entryRow, weight);
+      }
+    });
+    updateSelectedEmptyState();
   }
+
+  if (addManualButton) {
+    addManualButton.addEventListener('click', function() {
+      addManualRow();
+    });
+  }
+
+  if (entrantSelectAll) {
+    entrantSelectAll.addEventListener('change', function() {
+      var checked = entrantSelectAll.checked;
+      $all('.idm-entrant-checkbox').forEach(function(box) {
+        if (box.checked === checked) {
+          return;
+        }
+        box.checked = checked;
+        handleEntrantToggle(box);
+      });
+      updateEntrantSelectAll();
+    });
+  }
+
+  document.addEventListener('change', function(event) {
+    if (event.target && event.target.classList && event.target.classList.contains('idm-entrant-checkbox')) {
+      handleEntrantToggle(event.target);
+    }
+  });
 
   document.addEventListener('click', function(event) {
-    if (event.target && event.target.classList.contains('idm-remove-weight')) {
-      var row = event.target.closest('.idm-weight-row');
+    if (event.target && event.target.classList && event.target.classList.contains('idm-remove-weight')) {
+      var row = event.target.closest('.idm-manual-row');
       if (row && !row.hasAttribute('data-template')) {
         event.preventDefault();
         row.parentNode.removeChild(row);
+        renumberManualRows();
+      }
+    }
+
+    if (event.target && event.target.classList && event.target.classList.contains('idm-remove-selected')) {
+      event.preventDefault();
+      var selectedRow = event.target.closest('.idm-selected-row');
+      if (selectedRow) {
+        removeSelectedRowByKey(selectedRow.getAttribute('data-entry-key'));
       }
     }
   });
+
+  if (selectedBody) {
+    selectedBody.addEventListener('input', function(event) {
+      if (event.target && event.target.getAttribute('data-field') === 'weight') {
+        var row = event.target.closest('.idm-selected-row');
+        if (!row) {
+          return;
+        }
+        var key = row.getAttribute('data-entry-key');
+        var weight = parseInt(event.target.value, 10);
+        if (!key || isNaN(weight) || weight <= 0) {
+          return;
+        }
+        var entryRow = getEntryRowByKey(key);
+        if (entryRow) {
+          syncEntryWeightDisplay(entryRow, weight);
+        }
+      }
+    });
+  }
+
+  if (selectedBulkButton && selectedBulkInput && selectedBody) {
+    selectedBulkButton.addEventListener('click', function() {
+      var rawValue = selectedBulkInput.value;
+      if (rawValue === '') {
+        selectedBulkInput.focus();
+        return;
+      }
+
+      var number = parseInt(rawValue, 10);
+      if (isNaN(number)) {
+        selectedBulkInput.focus();
+        return;
+      }
+
+      var min = parseInt(selectedBulkInput.getAttribute('min'), 10);
+      var max = parseInt(selectedBulkInput.getAttribute('max'), 10);
+      if (!isNaN(min) && number < min) {
+        number = min;
+      }
+      if (!isNaN(max) && number > max) {
+        number = max;
+      }
+
+      selectedBulkInput.value = number;
+
+      $all('.idm-selected-row', selectedBody).forEach(function(row) {
+        var weightField = row.querySelector('[data-field="weight"]');
+        if (weightField) {
+          weightField.value = number;
+        }
+        var key = row.getAttribute('data-entry-key');
+        if (key) {
+          var entryRow = getEntryRowByKey(key);
+          if (entryRow) {
+            syncEntryWeightDisplay(entryRow, number);
+          }
+        }
+      });
+    });
+  }
 
   var drawButton = document.getElementById('idm-draw-button');
   var resultBox = document.getElementById('idm-draw-result');


### PR DESCRIPTION
## Summary
- add selection checkboxes to the applicant list and surface checked entrants below for bulk percentage updates
- rework the weight form to separate selected entrants from additional manual conditions and support member ID based rules
- update dashboard styling and scripting to manage entrant selection syncing, bulk editing, and manual row renumbering
- fix PHP 7.0 compatibility by removing the nullable array type hint from the campaign selector helper

## Testing
- php -l admin/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd1f54ea1c83238240f6bae291011a