### PR TITLE
Hide applicant emails and shift weighting UI to names

### DIFF
--- a/idm-membership/admin/class-admin.php
+++ b/idm-membership/admin/class-admin.php
@@ -30,15 +30,6 @@ class Admin {
             'dashicons-groups',
             58
         );
-
-        add_submenu_page(
-            $slug,
-            __('ダッシュボード', 'idm-membership'),
-            __('ダッシュボード', 'idm-membership'),
-            'manage_options',
-            $slug,
-            [__CLASS__, 'render_dashboard']
-        );
     }
 
     public static function enqueue_assets($hook) {
@@ -72,9 +63,15 @@ class Admin {
                 'ajaxUrl'  => admin_url('admin-ajax.php'),
                 'nonce'    => wp_create_nonce('idm_draw_campaign'),
                 'campaign' => $selected_campaign,
+                'defaultWeight' => self::DEFAULT_WEIGHT,
                 'i18n'     => [
-                    'noEntries' => __('応募者がいません。', 'idm-membership'),
-                    'drawing'   => __('抽選中...', 'idm-membership'),
+                    'noEntries'     => __('応募者がいません。', 'idm-membership'),
+                    'drawing'       => __('抽選中...', 'idm-membership'),
+                    'selectedNone'  => __('選択された応募者がありません。', 'idm-membership'),
+                    'weightInvalid' => __('抽選確率は1以上の数値を入力してください。', 'idm-membership'),
+                    'applySuccess'  => __('抽選確率を適用しました。設定を保存してください。', 'idm-membership'),
+                    'applyPartial'  => __('抽選確率を適用しましたが、名前が未設定の応募者は対象外です。', 'idm-membership'),
+                    'applyFailed'   => __('抽選確率を適用できませんでした。対象となる応募者を選択してください。', 'idm-membership'),
                 ],
             ]
         );
@@ -175,30 +172,51 @@ class Admin {
         echo '<table class="widefat fixed striped">';
         echo '<thead><tr>';
         echo '<th>' . esc_html__('名前', 'idm-membership') . '</th>';
-        echo '<th>' . esc_html__('メールアドレス', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('応募日時', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('抽選確率(%)', 'idm-membership') . '</th>';
         echo '</tr></thead>';
         echo '<tbody class="idm-entrant-list">';
         foreach ($entries as $entry) {
-            $name  = $entry['name'] !== '' ? $entry['name'] : __('(未設定)', 'idm-membership');
-            $email = $entry['email'] !== '' ? $entry['email'] : __('(メール不明)', 'idm-membership');
+            $raw_name  = isset($entry['name']) ? (string) $entry['name'] : '';
+            $name      = $raw_name !== '' ? $raw_name : __('(未設定)', 'idm-membership');
+            $joined_at = isset($entry['joined_at']) ? (string) $entry['joined_at'] : '';
+            $weight    = isset($entry['weight']) ? (int) $entry['weight'] : self::DEFAULT_WEIGHT;
+
             printf(
-                '<tr class="idm-entrant" data-member-id="%1$d" data-weight="%4$d"><td>%2$s</td><td>%3$s</td><td>%5$s</td><td>%4$d</td></tr>',
+                '<tr class="idm-entrant" data-member-id="%1$d" data-weight="%4$d" data-name="%5$s">'
+                . '<td class="idm-entrant-name"><label><input type="checkbox" class="idm-entrant-select" value="%1$d" /> '
+                . '<span class="idm-entrant-name-text">%2$s</span></label></td>'
+                . '<td>%3$s</td>'
+                . '<td class="idm-entrant-weight">%4$d</td>'
+                . '</tr>',
                 (int) $entry['member_id'],
                 esc_html($name),
-                esc_html($email),
-                (int) $entry['weight'],
-                esc_html($entry['joined_at'])
+                esc_html($joined_at),
+                (int) $weight,
+                esc_attr($raw_name)
             );
         }
         echo '</tbody>';
         echo '</table>';
+
+        $empty_text = __('応募者一覧でチェックを入れるとここに表示されます。', 'idm-membership');
+        echo '<div class="idm-selected-panel">';
+        echo '<h3>' . esc_html__('選択中の応募者', 'idm-membership') . '</h3>';
+        echo '<p class="idm-selected-empty" data-empty-text="' . esc_attr($empty_text) . '">' . esc_html($empty_text) . '</p>';
+        echo '<ul class="idm-selected-list"></ul>';
+        echo '<div class="idm-selected-actions">';
+        echo '<label>' . esc_html__('抽選確率(%)', 'idm-membership') . ' ';
+        echo '<input type="number" class="small-text idm-selected-weight" min="1" max="1000" step="1" value="' . esc_attr(self::DEFAULT_WEIGHT) . '" /></label> ';
+        echo '<button type="button" class="button idm-selected-apply">' . esc_html__('選択中に適用', 'idm-membership') . '</button>';
+        echo '</div>';
+        echo '<p class="description idm-selected-note">' . esc_html__('抽選確率の適用後は「設定を保存」を押して確定してください。', 'idm-membership') . '</p>';
+        echo '<p class="idm-selected-message" aria-live="polite"></p>';
+        echo '</div>';
     }
 
     private static function render_weights_form($campaign, array $weights) {
         echo '<h2>' . esc_html__('抽選確率の調整', 'idm-membership') . '</h2>';
-        echo '<p class="description">' . esc_html__('特定の会員を名前またはメールアドレスで指定し、抽選確率を％で上書きできます。未指定の応募者は100%（等確率）です。', 'idm-membership') . '</p>';
+        echo '<p class="description">' . esc_html__('特定の会員を名前で指定し、抽選確率を％で上書きできます。未指定の応募者は100%（等確率）です。', 'idm-membership') . '</p>';
 
         echo '<form method="post" class="idm-weights-form">';
         wp_nonce_field('idm_save_weights');
@@ -207,51 +225,92 @@ class Admin {
 
         echo '<table class="widefat fixed striped">';
         echo '<thead><tr>';
-        echo '<th>' . esc_html__('対象', 'idm-membership') . '</th>';
-        echo '<th>' . esc_html__('識別値', 'idm-membership') . '</th>';
+        echo '<th>' . esc_html__('名前', 'idm-membership') . '</th>';
         echo '<th>' . esc_html__('確率(%)', 'idm-membership') . '</th>';
         echo '<th class="idm-column-actions"></th>';
         echo '</tr></thead>';
-        echo '<tbody id="idm-weight-rows">';
-
         if (empty($weights)) {
             $weights = [];
         }
 
+        $rows = [];
         $index = 0;
+        $has_hidden = false;
         foreach ($weights as $weight) {
-            $field  = isset($weight['field']) ? $weight['field'] : 'email';
+            $field  = isset($weight['field']) ? $weight['field'] : 'name';
             $value  = isset($weight['value']) ? $weight['value'] : '';
-            $chance = isset($weight['weight']) ? (int)$weight['weight'] : self::DEFAULT_WEIGHT;
-            self::render_weight_row($index, $field, $value, $chance);
+            $chance = isset($weight['weight']) ? (int) $weight['weight'] : self::DEFAULT_WEIGHT;
+            $is_hidden = ($field !== 'name');
+            if ($is_hidden) {
+                $has_hidden = true;
+            }
+            $rows[] = [
+                'index'  => $index,
+                'field'  => $field,
+                'value'  => $value,
+                'chance' => $chance,
+                'hidden' => $is_hidden,
+            ];
             $index++;
         }
 
+        echo '<tbody id="idm-weight-rows" data-next-index="' . esc_attr($index) . '">';
+        foreach ($rows as $row) {
+            self::render_weight_row($row['index'], $row['field'], $row['value'], $row['chance'], false, $row['hidden']);
+        }
+
         // Empty template row (will be cloned by JS when adding new rule).
-        self::render_weight_row('__INDEX__', 'email', '', self::DEFAULT_WEIGHT, true);
+        self::render_weight_row('__INDEX__', 'name', '', self::DEFAULT_WEIGHT, true);
 
         echo '</tbody>';
         echo '</table>';
 
         echo '<p><button type="button" class="button" id="idm-add-weight">' . esc_html__('＋ 条件を追加', 'idm-membership') . '</button></p>';
+        if ($has_hidden) {
+            echo '<p class="description idm-weight-hidden-note">' . esc_html__('過去にメールアドレスで設定した抽選確率は保持されています。必要に応じて該当行を削除し、名前で再登録してください。', 'idm-membership') . '</p>';
+        }
         submit_button(__('設定を保存', 'idm-membership'));
         echo '</form>';
     }
 
-    private static function render_weight_row($index, $field, $value, $chance, $is_template = false) {
-        $tr_class = $is_template ? 'idm-weight-row is-template' : 'idm-weight-row';
+    private static function render_weight_row($index, $field, $value, $chance, $is_template = false, $is_hidden = false) {
+        $classes = ['idm-weight-row'];
+        if ($is_template) {
+            $classes[] = 'is-template';
+        }
+        if ($is_hidden) {
+            $classes[] = 'is-hidden-value';
+        }
+
+        $attributes = '';
+        if ($is_template) {
+            $attributes .= ' data-template="1"';
+        }
+        if ($is_template) {
+            $attributes .= ' style="display:none;"';
+        }
+
         $name_prefix = is_numeric($index) ? 'weights[' . $index . ']' : 'weights[__INDEX__]';
         $disabled = $is_template ? ' disabled="disabled"' : '';
 
-        echo '<tr class="' . esc_attr($tr_class) . '"' . ($is_template ? ' data-template="1" style="display:none;"' : '') . '>';
-        echo '<td>';
-        echo '<select name="' . esc_attr($name_prefix . '[field]') . '"' . $disabled . '>';
-        printf('<option value="email" %s>%s</option>', selected($field, 'email', false), esc_html__('メールアドレス', 'idm-membership'));
-        printf('<option value="name" %s>%s</option>', selected($field, 'name', false), esc_html__('名前', 'idm-membership'));
-        echo '</select>';
-        echo '</td>';
-        echo '<td><input type="text" name="' . esc_attr($name_prefix . '[value]') . '" value="' . esc_attr($value) . '" class="regular-text"' . $disabled . ' /></td>';
-        echo '<td><input type="number" name="' . esc_attr($name_prefix . '[weight]') . '" value="' . esc_attr($chance) . '" min="1" max="1000" class="small-text"' . $disabled . ' /> %</td>';
+        echo '<tr class="' . esc_attr(implode(' ', $classes)) . '"' . $attributes . '>';
+
+        if ($is_hidden) {
+            echo '<td colspan="2" class="idm-weight-hidden-cell">';
+            echo '<input type="hidden" name="' . esc_attr($name_prefix . '[field]') . '" value="' . esc_attr($field) . '" class="idm-weight-field"' . $disabled . ' />';
+            echo '<input type="hidden" name="' . esc_attr($name_prefix . '[value]') . '" value="' . esc_attr($value) . '" class="idm-weight-value"' . $disabled . ' />';
+            echo '<input type="hidden" name="' . esc_attr($name_prefix . '[weight]') . '" value="' . esc_attr($chance) . '" class="idm-weight-weight"' . $disabled . ' />';
+            echo '<span class="idm-weight-hidden-label">' . esc_html__('メールアドレス指定の抽選設定（非表示）', 'idm-membership') . '</span>';
+            echo '<span class="idm-weight-hidden-weight">' . sprintf(esc_html__('現在の確率: %d%%', 'idm-membership'), (int) $chance) . '</span>';
+            echo '</td>';
+        } else {
+            echo '<td>';
+            echo '<input type="hidden" name="' . esc_attr($name_prefix . '[field]') . '" value="' . esc_attr($field) . '" class="idm-weight-field"' . $disabled . ' />';
+            echo '<input type="text" name="' . esc_attr($name_prefix . '[value]') . '" value="' . esc_attr($value) . '" class="regular-text idm-weight-value"' . $disabled . ' />';
+            echo '</td>';
+            echo '<td><input type="number" name="' . esc_attr($name_prefix . '[weight]') . '" value="' . esc_attr($chance) . '" min="1" max="1000" class="small-text idm-weight-weight"' . $disabled . ' /> %</td>';
+        }
+
         echo '<td class="idm-column-actions"><button type="button" class="button-link-delete idm-remove-weight"' . ($is_template ? ' disabled="disabled"' : '') . '>' . esc_html__('削除', 'idm-membership') . '</button></td>';
         echo '</tr>';
     }
@@ -326,9 +385,9 @@ class Admin {
         }
 
         foreach ($weights as $weight) {
-            $field = isset($weight['field']) ? sanitize_key($weight['field']) : 'email';
+            $field = isset($weight['field']) ? sanitize_key($weight['field']) : 'name';
             if (!in_array($field, ['email', 'name'], true)) {
-                $field = 'email';
+                $field = 'name';
             }
 
             $value = isset($weight['value']) ? sanitize_text_field($weight['value']) : '';
@@ -422,7 +481,7 @@ class Admin {
         foreach ($entries as &$entry) {
             $entry['weight'] = self::DEFAULT_WEIGHT;
             foreach ($weights as $rule) {
-                $field = $rule['field'] ?? 'email';
+                $field = $rule['field'] ?? 'name';
                 $value = $rule['value'] ?? '';
                 $chance = isset($rule['weight']) ? (int) $rule['weight'] : self::DEFAULT_WEIGHT;
 

--- a/idm-membership/admin/dashboard.css
+++ b/idm-membership/admin/dashboard.css
@@ -18,8 +18,39 @@
   background-color: #fde68a;
 }
 
+.idm-dashboard .idm-entrant-name label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.idm-dashboard .idm-entrant-list tr.is-selected {
+  background-color: #eef6ff;
+}
+
 .idm-dashboard .idm-weights-form {
   margin-top: 24px;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-hidden-cell {
+  font-style: italic;
+  color: #646970;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-hidden-label {
+  display: block;
+  font-style: normal;
+  font-weight: 600;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-hidden-weight {
+  display: block;
+  margin-top: 4px;
+}
+
+.idm-dashboard .idm-weight-hidden-note {
+  margin-top: -8px;
+  color: #646970;
 }
 
 .idm-dashboard .idm-weights-form table input[type="number"] {
@@ -59,4 +90,66 @@
   padding: 12px 16px;
   background: #f8f8f8;
   border-radius: 4px;
+}
+
+.idm-dashboard .idm-selected-panel {
+  margin-top: 16px;
+  padding: 16px;
+  border: 1px solid #ccd0d4;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.idm-dashboard .idm-selected-panel h3 {
+  margin-top: 0;
+}
+
+.idm-dashboard .idm-selected-empty {
+  margin: 0 0 12px;
+  color: #646970;
+}
+
+.idm-dashboard .idm-selected-list {
+  margin: 0 0 12px 18px;
+  padding-left: 0;
+  list-style: disc;
+  display: none;
+}
+
+.idm-dashboard .idm-selected-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.idm-dashboard .idm-selected-weight {
+  width: 6em;
+}
+
+.idm-dashboard .idm-selected-note {
+  margin-top: 8px;
+  color: #646970;
+}
+
+.idm-dashboard .idm-selected-message {
+  margin-top: 12px;
+  font-weight: 600;
+}
+
+.idm-dashboard .idm-selected-message.is-success {
+  color: #007017;
+}
+
+.idm-dashboard .idm-selected-message.is-warning {
+  color: #dba617;
+}
+
+.idm-dashboard .idm-selected-message.is-error {
+  color: #d63638;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-row.is-highlighted {
+  background-color: #fef3c7;
+  transition: background-color 0.3s ease;
 }

--- a/idm-membership/admin/dashboard.js
+++ b/idm-membership/admin/dashboard.js
@@ -7,11 +7,11 @@
     return Array.prototype.slice.call((context || document).querySelectorAll(selector));
   }
 
-  function addWeightRow() {
+  function addWeightRow(initialData) {
     var template = document.querySelector('.idm-weight-row[data-template="1"]');
     var tbody = document.getElementById('idm-weight-rows');
     if (!template || !tbody) {
-      return;
+      return null;
     }
 
     var clone = template.cloneNode(true);
@@ -22,30 +22,46 @@
       el.removeAttribute('disabled');
     });
 
-    var index = tbody.querySelectorAll('.idm-weight-row:not([data-template])').length;
+    var nextIndex = parseInt(tbody.getAttribute('data-next-index') || '0', 10);
+    if (isNaN(nextIndex) || nextIndex < 0) {
+      nextIndex = 0;
+    }
     $all('[name]', clone).forEach(function(el) {
       var name = el.getAttribute('name');
       if (name) {
-        el.setAttribute('name', name.replace('__INDEX__', index));
+        el.setAttribute('name', name.replace('__INDEX__', nextIndex));
       }
       if (el.tagName === 'INPUT') {
         el.value = '';
+        el.setAttribute('value', '');
       }
     });
 
-    var select = $('select', clone);
-    if (select) {
-      select.value = 'email';
+    var fieldInput = clone.querySelector('.idm-weight-field');
+    if (fieldInput) {
+      var fieldValue = initialData && initialData.field ? initialData.field : 'name';
+      fieldInput.value = fieldValue;
+      fieldInput.setAttribute('value', fieldValue);
     }
 
-    var number = $('input[type="number"]', clone);
+    var textInput = clone.querySelector('.idm-weight-value');
+    if (textInput) {
+      var textValue = initialData && initialData.value ? initialData.value : '';
+      textInput.value = textValue;
+      textInput.setAttribute('value', textValue);
+    }
+
+    var number = clone.querySelector('.idm-weight-weight');
     if (number) {
-      var baseValue = number.getAttribute('value') || 100;
-      number.value = baseValue;
-      number.setAttribute('value', baseValue);
+      var fallback = number.getAttribute('value') || (window.idmDashboard && idmDashboard.defaultWeight ? idmDashboard.defaultWeight : 100);
+      var weightValue = (initialData && typeof initialData.weight !== 'undefined') ? initialData.weight : fallback;
+      number.value = weightValue;
+      number.setAttribute('value', weightValue);
     }
 
     tbody.appendChild(clone);
+    tbody.setAttribute('data-next-index', String(nextIndex + 1));
+    return clone;
   }
 
   var addButton = document.getElementById('idm-add-weight');
@@ -62,6 +78,235 @@
       }
     }
   });
+
+  var selectedEntries = {};
+  var selectedOrder = [];
+  var selectedList = document.querySelector('.idm-selected-list');
+  var selectedEmpty = document.querySelector('.idm-selected-empty');
+  var selectedMessage = document.querySelector('.idm-selected-message');
+  var selectedWeightInput = document.querySelector('.idm-selected-weight');
+  var applySelectedButton = document.querySelector('.idm-selected-apply');
+  var messageFallbacks = {
+    selectedNone: '選択された応募者がありません。',
+    weightInvalid: '抽選確率は1以上の数値を入力してください。',
+    applySuccess: '抽選確率を適用しました。設定を保存してください。',
+    applyPartial: '抽選確率を適用しましたが、名前が未設定の応募者は対象外です。',
+    applyFailed: '抽選確率を適用できませんでした。対象となる応募者を選択してください。'
+  };
+
+  function getMessage(key) {
+    if (window.idmDashboard && idmDashboard.i18n && idmDashboard.i18n[key]) {
+      return idmDashboard.i18n[key];
+    }
+    return messageFallbacks[key] || '';
+  }
+
+  function setSelectedMessage(text, status) {
+    if (!selectedMessage) {
+      return;
+    }
+    selectedMessage.textContent = text || '';
+    selectedMessage.className = 'idm-selected-message';
+    if (status) {
+      selectedMessage.classList.add('is-' + status);
+    }
+  }
+
+  function addSelectedEntry(id, data) {
+    if (!selectedEntries[id]) {
+      selectedOrder.push(id);
+    }
+    selectedEntries[id] = data;
+  }
+
+  function removeSelectedEntry(id) {
+    if (!selectedEntries[id]) {
+      return;
+    }
+    delete selectedEntries[id];
+    var index = selectedOrder.indexOf(id);
+    if (index >= 0) {
+      selectedOrder.splice(index, 1);
+    }
+  }
+
+  function getSelectedEntries() {
+    return selectedOrder
+      .map(function(id) { return selectedEntries[id]; })
+      .filter(function(entry) { return !!entry; });
+  }
+
+  function updateSelectedDisplay() {
+    if (!selectedList || !selectedEmpty) {
+      return;
+    }
+
+    var entries = getSelectedEntries();
+    selectedList.innerHTML = '';
+
+    if (!entries.length) {
+      selectedList.style.display = 'none';
+      selectedEmpty.style.display = '';
+      setSelectedMessage('');
+      return;
+    }
+
+    selectedEmpty.style.display = 'none';
+    selectedList.style.display = '';
+
+    entries.forEach(function(entry) {
+      var li = document.createElement('li');
+      var label = entry.displayName || entry.rawName || '';
+      li.textContent = label;
+      selectedList.appendChild(li);
+    });
+  }
+
+  function highlightWeightRow(row) {
+    if (!row) {
+      return;
+    }
+    row.classList.add('is-highlighted');
+    setTimeout(function() {
+      row.classList.remove('is-highlighted');
+    }, 1500);
+  }
+
+  function ensureWeightRow(field, value, weight) {
+    var tbody = document.getElementById('idm-weight-rows');
+    if (!tbody) {
+      return null;
+    }
+
+    var rows = $all('.idm-weight-row', tbody).filter(function(row) {
+      return !row.hasAttribute('data-template');
+    });
+
+    var targetRow = null;
+    rows.some(function(row) {
+      var fieldInput = row.querySelector('.idm-weight-field');
+      var valueInput = row.querySelector('.idm-weight-value');
+      if (!fieldInput || !valueInput) {
+        return false;
+      }
+      if (fieldInput.value === field && valueInput.value === value) {
+        targetRow = row;
+        return true;
+      }
+      return false;
+    });
+
+    if (!targetRow) {
+      targetRow = addWeightRow({ field: field, value: value, weight: weight });
+    }
+
+    if (!targetRow) {
+      return null;
+    }
+
+    var fieldEl = targetRow.querySelector('.idm-weight-field');
+    if (fieldEl) {
+      fieldEl.value = field;
+      fieldEl.setAttribute('value', field);
+    }
+
+    var valueEl = targetRow.querySelector('.idm-weight-value');
+    if (valueEl) {
+      valueEl.value = value;
+      valueEl.setAttribute('value', value);
+    }
+
+    var numberEl = targetRow.querySelector('.idm-weight-weight');
+    if (numberEl) {
+      numberEl.value = weight;
+      numberEl.setAttribute('value', weight);
+    }
+
+    highlightWeightRow(targetRow);
+    return targetRow;
+  }
+
+  $all('.idm-entrant-select').forEach(function(checkbox) {
+    checkbox.addEventListener('change', function() {
+      var row = checkbox.closest('.idm-entrant');
+      if (!row) {
+        return;
+      }
+
+      var memberId = row.getAttribute('data-member-id') || checkbox.value;
+      if (!memberId) {
+        return;
+      }
+      memberId = String(memberId);
+
+      if (checkbox.checked) {
+        var nameEl = $('.idm-entrant-name-text', row);
+        var displayName = nameEl ? nameEl.textContent.trim() : '';
+        var rawName = (row.getAttribute('data-name') || '').trim();
+        if (!displayName) {
+          displayName = rawName;
+        }
+        addSelectedEntry(memberId, {
+          memberId: memberId,
+          rawName: rawName,
+          displayName: displayName || ''
+        });
+        row.classList.add('is-selected');
+      } else {
+        removeSelectedEntry(memberId);
+        row.classList.remove('is-selected');
+      }
+
+      updateSelectedDisplay();
+    });
+  });
+
+  if (applySelectedButton) {
+    applySelectedButton.addEventListener('click', function() {
+      var entries = getSelectedEntries();
+      if (!entries.length) {
+        setSelectedMessage(getMessage('selectedNone'), 'warning');
+        return;
+      }
+
+      if (!selectedWeightInput) {
+        return;
+      }
+
+      var weightValue = parseInt(selectedWeightInput.value, 10);
+      if (!weightValue || weightValue <= 0) {
+        setSelectedMessage(getMessage('weightInvalid'), 'error');
+        selectedWeightInput.focus();
+        return;
+      }
+
+      var processed = 0;
+      var skipped = 0;
+
+      entries.forEach(function(entry) {
+        var value = (entry.rawName || '').trim();
+        if (!value) {
+          skipped++;
+          return;
+        }
+        if (ensureWeightRow('name', value, weightValue)) {
+          processed++;
+        } else {
+          skipped++;
+        }
+      });
+
+      if (processed > 0 && skipped === 0) {
+        setSelectedMessage(getMessage('applySuccess'), 'success');
+      } else if (processed > 0) {
+        setSelectedMessage(getMessage('applyPartial'), 'warning');
+      } else {
+        setSelectedMessage(getMessage('applyFailed'), 'error');
+      }
+    });
+  }
+
+  updateSelectedDisplay();
 
   var drawButton = document.getElementById('idm-draw-button');
   var resultBox = document.getElementById('idm-draw-result');


### PR DESCRIPTION
## Summary
- remove the redundant submenu entry and adjust localized messaging to emphasize name-based control in the dashboard
- update the applicants table and weighting form to hide email addresses, work solely with names, and retain legacy email rules as hidden entries
- rework the dashboard script and styles to manage name-only selections, cloned rows, and hidden legacy notices while keeping the UI consistent

## Testing
- php -l admin/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68cd5a92e62c8323b8d6e59b0bc37a9c