### PR TITLE
Update member dashboard privacy and draw handling

### DIFF
--- a/idm-membership/admin/dashboard.css
+++ b/idm-membership/admin/dashboard.css
@@ -36,6 +36,26 @@
   width: 6em;
 }
 
+.idm-dashboard .idm-weights-form .idm-weight-identifier {
+  min-width: 220px;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-field-label.is-legacy {
+  color: #d63638;
+}
+
+.idm-dashboard .idm-weights-form .idm-weight-legacy-note {
+  margin: 4px 0 0;
+  color: #646970;
+  font-size: 12px;
+}
+
 .idm-dashboard .idm-weights-form .idm-column-actions {
   width: 100px;
   text-align: center;

--- a/idm-membership/includes/class-install.php
+++ b/idm-membership/includes/class-install.php
@@ -29,6 +29,8 @@ class Install {
         // Optional safety: ensure name/role exist (older drafts)
         self::ensure_column($members, 'name', "VARCHAR(255) NOT NULL DEFAULT ''");
         self::ensure_column($members, 'role', "VARCHAR(50) NOT NULL DEFAULT 'member'");
+
+        self::ensure_winners_table();
     }
 
     private static function ensure_column($table, $column, $definition) {
@@ -103,5 +105,43 @@ class Install {
         dbDelta($sql_tokens);
         dbDelta($sql_tags);
         dbDelta($sql_joins);
+        dbDelta(self::winners_table_sql($charset_collate));
+    }
+
+    private static function ensure_winners_table() {
+        global $wpdb;
+        $winners = $wpdb->prefix . 'idm_campaign_winners';
+        $exists  = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $winners));
+
+        if ($exists !== $winners) {
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+            dbDelta(self::winners_table_sql($wpdb->get_charset_collate()));
+            return;
+        }
+
+        self::ensure_column($winners, 'entry_id', "BIGINT(20) UNSIGNED NULL");
+        self::ensure_column($winners, 'winner_name', "VARCHAR(255) NOT NULL DEFAULT ''");
+        self::ensure_column($winners, 'winner_email', "VARCHAR(190) NOT NULL DEFAULT ''");
+        self::ensure_column($winners, 'winner_weight', "INT(11) NOT NULL DEFAULT 0");
+        self::ensure_column($winners, 'drawn_at', "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP");
+    }
+
+    private static function winners_table_sql($charset_collate) {
+        global $wpdb;
+        $winners = $wpdb->prefix . 'idm_campaign_winners';
+
+        return "CREATE TABLE {$winners} (
+            id BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+            campaign_key VARCHAR(100) NOT NULL,
+            winner_member_id BIGINT(20) UNSIGNED NOT NULL,
+            entry_id BIGINT(20) UNSIGNED NULL,
+            winner_name VARCHAR(255) NOT NULL DEFAULT '',
+            winner_email VARCHAR(190) NOT NULL DEFAULT '',
+            winner_weight INT(11) NOT NULL DEFAULT 0,
+            drawn_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY  (id),
+            KEY campaign_key (campaign_key),
+            KEY winner_member_id (winner_member_id)
+        ) {$charset_collate};";
     }
 }


### PR DESCRIPTION
## Summary
- Remove the duplicate submenu entry and strip email data from the admin applicant list, selection panel, and draw result displays while keeping the dashboard flow intact.【F:admin/class-admin.php†L21-L215】【F:admin/dashboard.js†L10-L374】
- Rework the weighting UI to operate on member names only, flag legacy email-based rules, and update supporting styles and scripts for the streamlined controls.【F:admin/class-admin.php†L218-L336】【F:admin/dashboard.js†L10-L322】【F:admin/dashboard.css†L40-L57】
- Persist each draw winner and ensure the installer provisions the campaign winners table for existing installs.【F:admin/class-admin.php†L484-L590】【F:includes/class-install.php†L18-L145】

## Testing
- php -l admin/class-admin.php【ec17f1†L1-L2】
- php -l includes/class-install.php【584ae0†L1-L2】

------
https://chatgpt.com/codex/tasks/task_e_68cd6e2273a08323a49d517da92e4649