### PR TITLE
Fix dashboard campaign selection for uppercase keys

### DIFF
--- a/idm-membership/admin/class-admin.php
+++ b/idm-membership/admin/class-admin.php
@@ -322,7 +322,7 @@ class Admin {
 
         check_admin_referer('idm_save_weights');
 
-        $submitted_campaign = isset($_POST['campaign']) ? sanitize_key(wp_unslash($_POST['campaign'])) : '';
+        $submitted_campaign = isset($_POST['campaign']) ? self::sanitize_campaign_key(wp_unslash($_POST['campaign'])) : '';
         if ($submitted_campaign === '') {
             self::$messages[] = [
                 'type'    => 'notice notice-error',
@@ -406,8 +406,14 @@ class Admin {
         return $campaigns;
     }
 
+    private static function sanitize_campaign_key($value) {
+        $value = (string) $value;
+        $value = preg_replace('/[^A-Za-z0-9_\-]/', '', $value);
+        return $value;
+    }
+
     private static function get_selected_campaign(?array $available = null) {
-        $campaign = isset($_GET['campaign']) ? sanitize_key(wp_unslash($_GET['campaign'])) : '';
+        $campaign = isset($_GET['campaign']) ? self::sanitize_campaign_key(wp_unslash($_GET['campaign'])) : '';
         if ($campaign !== '') {
             if (empty($available) || in_array($campaign, $available, true)) {
                 return $campaign;
@@ -499,7 +505,7 @@ class Admin {
 
         check_ajax_referer('idm_draw_campaign', 'nonce');
 
-        $campaign = isset($_POST['campaign']) ? sanitize_key(wp_unslash($_POST['campaign'])) : '';
+        $campaign = isset($_POST['campaign']) ? self::sanitize_campaign_key(wp_unslash($_POST['campaign'])) : '';
         if ($campaign === '') {
             wp_send_json_error(['message' => __('キャンペーンが指定されていません。', 'idm-membership')]);
         }
@@ -536,7 +542,7 @@ class Admin {
 
         check_ajax_referer('idm_draw_campaign', 'nonce');
 
-        $campaign = isset($_POST['campaign']) ? sanitize_key(wp_unslash($_POST['campaign'])) : '';
+        $campaign = isset($_POST['campaign']) ? self::sanitize_campaign_key(wp_unslash($_POST['campaign'])) : '';
         if ($campaign === '') {
             wp_send_json_error(['message' => __('キャンペーンが指定されていません。', 'idm-membership')]);
         }


### PR DESCRIPTION
## Summary
- ensure dashboard campaign selection accepts stored keys without lowercasing
- add a dedicated sanitizer for campaign keys and reuse it across form and AJAX handlers

## Testing
- php -l devack/idm-membership/admin/class-admin.php

------
https://chatgpt.com/codex/tasks/task_e_68ddc0d9da048323b106753ea1182667